### PR TITLE
Feat/reorganize lambda responses

### DIFF
--- a/__tests__/lambda/formatters.test.ts
+++ b/__tests__/lambda/formatters.test.ts
@@ -1,4 +1,4 @@
-import { formattedResponse, lambdaResp, lambdaRespError, getBody } from '../../src/lambda'
+import { formattedResponse, getBody } from '../../src/lambda'
 
 describe('invoke', () => {
   it('Should returns response formatted with status code 401', () => {
@@ -29,34 +29,6 @@ describe('invoke', () => {
 
   it('Should returns response formatted without a payload', () => {
     expect(formattedResponse({ StatusCode: 200 })).toEqual({ body: {}, status: 200 })
-  })
-
-  it('Should returns lambda response formatted with a body string', () => {
-    expect(lambdaResp(201, 'Created')).toEqual({ body: 'Created', statusCode: 201 })
-  })
-
-  it('Should returns lambda response formatted with a body object', () => {
-    expect(lambdaResp(201, { user: 'Created' })).toEqual({ body: '{"user":"Created"}', statusCode: 201 })
-  })
-
-  it('Should returns lambda response error formatted with status and message', () => {
-    expect(lambdaRespError({ status: 404, message: 'User Not Found' })).toEqual({ statusCode: 404, body: '{"error":"User Not Found"}' })
-  })
-
-  it('Should returns lambda response error formatted with status code and error', () => {
-    expect(lambdaRespError({ statusCode: 404, error: { user: 'Not Found' } })).toEqual({ statusCode: 404, body: '{"error":{"user":"Not Found"}}' })
-  })
-
-  it('Should returns lambda response error formatted without status', () => {
-    expect(lambdaRespError({ message: 'Invalid field' })).toEqual({ statusCode: 500, body: '{"error":"Invalid field"}' })
-  })
-
-  it('Should returns lambda response error formatted without message', () => {
-    expect(lambdaRespError({ statusCode: 500 })).toEqual({ statusCode: 500, body: '' })
-  })
-
-  it('Should returns lambda response error formatted without status and message', () => {
-    expect(lambdaRespError({})).toEqual({ statusCode: 500, body: '' })
   })
 })
 

--- a/__tests__/lambda/lambdaResponses.test.ts
+++ b/__tests__/lambda/lambdaResponses.test.ts
@@ -101,3 +101,31 @@ describe('lambdaRespError', () => {
     expect(lambdaRespError(param.error)).toStrictEqual(param.response)
   })
 })
+
+it('Should returns lambda response formatted with a body string', () => {
+  expect(lambdaResp(201, 'Created')).toEqual({ body: 'Created', statusCode: 201 })
+})
+
+it('Should returns lambda response formatted with a body object', () => {
+  expect(lambdaResp(201, { user: 'Created' })).toEqual({ body: '{"user":"Created"}', statusCode: 201 })
+})
+
+it('Should returns lambda response error formatted with status and message', () => {
+  expect(lambdaRespError({ status: 404, message: 'User Not Found' })).toEqual({ statusCode: 404, body: '{"error":"User Not Found"}' })
+})
+
+it('Should returns lambda response error formatted with status code and error', () => {
+  expect(lambdaRespError({ statusCode: 404, error: { user: 'Not Found' } })).toEqual({ statusCode: 404, body: '{"error":{"user":"Not Found"}}' })
+})
+
+it('Should returns lambda response error formatted without status', () => {
+  expect(lambdaRespError({ message: 'Invalid field' })).toEqual({ statusCode: 500, body: '{"error":"Invalid field"}' })
+})
+
+it('Should returns lambda response error formatted without message', () => {
+  expect(lambdaRespError({ statusCode: 500 })).toEqual({ statusCode: 500, body: '' })
+})
+
+it('Should returns lambda response error formatted without status and message', () => {
+  expect(lambdaRespError({})).toEqual({ statusCode: 500, body: '' })
+})

--- a/__tests__/lambda/lambdaResponses.test.ts
+++ b/__tests__/lambda/lambdaResponses.test.ts
@@ -1,0 +1,103 @@
+import { lambdaResp, lambdaRespError } from '../../src/lambda'
+// import type { Error } from '../../src/lambda'
+
+describe('lambdaResp', () => {
+  const data = [
+    {
+      input: {
+        statusCode: 200,
+        body: ''
+      },
+      output: {
+        statusCode: 200,
+        body: ''
+      }
+    },
+    {
+      input: {
+        statusCode: 201,
+        body: {
+          message: 'Created!',
+          internalCode: '1032'
+        }
+      },
+      output: {
+        statusCode: 201,
+        body: '{"message":"Created!","internalCode":"1032"}'
+      }
+    },
+    {
+      input: {
+        statusCode: 404,
+        body: 'not found!'
+      },
+      output: {
+        statusCode: 404,
+        body: 'not found!'
+      }
+    }
+  ]
+
+  test.each(data)('Should return an response Object, with statusCode and body props', (param) => {
+    expect(lambdaResp(param.input.statusCode, param.input.body)).toStrictEqual(param.output)
+  })
+})
+
+describe('lambdaRespError', () => {
+  const data = [
+    {
+      error: {
+        status: 500,
+        error: 'all wrong! Do it right'
+      },
+      response: {
+        statusCode: 500,
+        body: '{"error":"all wrong! Do it right"}'
+      }
+    },
+    {
+      error: {
+        oneRandomProp: 404,
+        anotherRandomProp: 'all wrong! Do it right'
+      },
+      response: {
+        statusCode: 500,
+        body: ''
+      }
+    },
+    {
+      error: {
+        statusCode: 404,
+        message: 'these are not the droids you\'re looking for. move along'
+      },
+      response: {
+        statusCode: 404,
+        body: '{"error":"these are not the droids you\'re looking for. move along"}'
+      }
+    },
+    {
+      error: {
+        statusCode: NaN,
+        message: 'these are not the droids you\'re looking for. move along'
+      },
+      response: {
+        statusCode: 500,
+        body: '{"error":"these are not the droids you\'re looking for. move along"}'
+      }
+    },
+    {
+      error: {
+        status: NaN,
+        message: 'these are not the droids you\'re looking for. move along'
+      },
+      response: {
+        statusCode: 500,
+        body: '{"error":"these are not the droids you\'re looking for. move along"}'
+      }
+    }
+  ]
+
+  test.each(data)('Should return an error response Object, with statusCode and body props', (param) => {
+    expect(lambdaRespError(param.error)).toStrictEqual(param.response)
+  })
+})

--- a/src/lambda/formatters.ts
+++ b/src/lambda/formatters.ts
@@ -1,12 +1,4 @@
-import { isNumber } from '../number'
-import { objToStr, isObject } from '../object'
-import { ProxyResult } from 'aws-lambda'
-interface Error {
-  status?: number
-  statusCode?: number
-  error?: any
-  message?: string
-}
+import { isObject } from '../object'
 
 export const formattedResponse = ({ StatusCode, Payload }: { StatusCode?: any, Payload?: any }): object => {
   const payloadFormatted = JSON.parse(Payload || '{}')
@@ -15,21 +7,6 @@ export const formattedResponse = ({ StatusCode, Payload }: { StatusCode?: any, P
     status: payloadFormatted.statusCode || StatusCode,
     body: payloadFormatted.body ? JSON.parse(payloadFormatted.body) : {}
   }
-}
-
-export const lambdaResp = (statusCode: number, body?: object | string): ProxyResult => ({
-  statusCode,
-  ...(body ? { body: objToStr(body) } : { body: '' })
-})
-
-export const lambdaRespError = (err: Error): ProxyResult => {
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-  err.statusCode = err.status || err.statusCode
-  err.message = err.error || err.message
-
-  if (err && isNumber(err.statusCode)) return lambdaResp(Number(err.statusCode), (err.message) ? { error: err.message } : undefined)
-
-  return lambdaResp(500, (err.message) ? { error: err.message } : undefined)
 }
 
 export const getBody = (event: { body: string } | string | any, defaultValue: any = null): object | any => {

--- a/src/lambda/index.ts
+++ b/src/lambda/index.ts
@@ -1,2 +1,6 @@
 export * from './formatters'
 export * from './lambdaService'
+export * from './lambdaGetParameters'
+export * from './lambdaCheckParameters'
+export * from './lambdaResponses'
+export * from './interfaces'

--- a/src/lambda/interfaces.ts
+++ b/src/lambda/interfaces.ts
@@ -1,5 +1,6 @@
-export interface LambdaResp {
-  statusCode: (number|undefined)
+export interface Error {
+  status?: number
+  statusCode?: number
+  error?: any
   message?: string
-  body?: object
 }

--- a/src/lambda/lambdaResponses.ts
+++ b/src/lambda/lambdaResponses.ts
@@ -1,0 +1,18 @@
+import { isNumber } from '../number'
+import { objToStr } from '../object'
+import { ProxyResult } from 'aws-lambda'
+import type { Error } from './interfaces'
+
+export const lambdaResp = (statusCode: number, body?: object | string): ProxyResult => ({
+  statusCode,
+  ...(body ? { body: objToStr(body) } : { body: '' })
+})
+
+export const lambdaRespError = (err: Error): ProxyResult => {
+  err.statusCode = err.status ?? err.statusCode
+  err.message = err.error ?? err.message
+
+  if (err && isNumber(err.statusCode)) return lambdaResp(Number(err.statusCode), (err.message) ? { error: err.message } : undefined)
+
+  return lambdaResp(500, (err.message) ? { error: err.message } : undefined)
+}


### PR DESCRIPTION
In this PR I just move the LambdaResponse functions to a file dedicated to them, for easily identification. @Viserion77 and me discussed about it and we thought that, this way, makes more sense.

Also! 
On lines 12-13 of lambdaResponses.ts, I changed from || to ??