### PR TITLE
chore: disable `@typescript-eslint/explicit-function-return-type`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,6 +8,7 @@
     "@typescript-eslint/no-namespace": "off",
     "@typescript-eslint/return-await": "off",
     "@typescript-eslint/no-non-null-assertion": "off",
-    "@typescript-eslint/strict-boolean-expressions": "off"
+    "@typescript-eslint/strict-boolean-expressions": "off",
+    "@typescript-eslint/explicit-function-return-type": "off"
   }
 }


### PR DESCRIPTION
Disable `@typescript-eslint/explicit-function-return-type`. TypeScript inferring is very useful with complex return types such as huge objects. Docs: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/explicit-function-return-type.md