### PR TITLE
Fix/add keyslist to prisma builder parameters

### DIFF
--- a/__tests__/prisma/prisma.test.ts
+++ b/__tests__/prisma/prisma.test.ts
@@ -135,7 +135,7 @@ describe('prismaBuilderParameters', () => {
           templateId: 77
         }
       },
-      settings: { settings: { joinKeys: true } },
+      settings: { settings: { joinKeys: true, keysList: ['appId', 'templateId'] } },
       output: {
         method: 'update',
         prismaParams: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "adapcon-utils-js",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adapcon-utils-js",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Utils library for Javascript",
   "keywords": [],
   "author": {

--- a/src/prisma/interfaces.ts
+++ b/src/prisma/interfaces.ts
@@ -30,6 +30,7 @@ export type EventFunctionType = (prismaInputParams: PrismaInputParams) => Prisma
 
 export type SettingsCrud = {
   joinKeys: boolean
+  keysList: string[]
 }
 
 export type BlockedMethods = {

--- a/src/prisma/prisma.ts
+++ b/src/prisma/prisma.ts
@@ -144,7 +144,14 @@ export const getPrismaStatusCode = <prismaEntity>(method: PrismaOutputParams['me
   }
 }
 
-export const formatEntitiesKeys = (keys?: {[key: string]: string|number}, settings?: SettingsCrud): {[key: string]: string|number|{[key: string]: string|number}} => {
+export const formatEntitiesKeys = (
+  keys?: {[key: string]: string|number},
+  settings?: SettingsCrud
+): {
+  [key: string]: string|number|{
+    [key: string]: string|number
+  }
+} => {
   const formattedKeys: {[key: string]: string|number} = keys ?? {}
   if (keys) {
     for (const key in keys) {
@@ -156,8 +163,7 @@ export const formatEntitiesKeys = (keys?: {[key: string]: string|number}, settin
   }
 
   if (settings?.joinKeys) {
-    const keysArray = Object.keys(formattedKeys)
-    const keysInJoin = keysArray.join('_')
+    const keysInJoin = settings.keysList.join('_')
     return {
       [keysInJoin]: formattedKeys
     }

--- a/src/secretsManager/secretManager.ts
+++ b/src/secretsManager/secretManager.ts
@@ -11,7 +11,7 @@ export const SecretManager = {
     if (!secret) throw new Error('Secret not found!')
     if (!secret.SecretString) throw new Error('Secret without a value!')
 
-    return JSON.parse(secret.SecretString ?? '{}')
+    return JSON.parse(secret.SecretString)
   },
 
   getAccessKey: async ({ region, serviceSecretArn: secretId, isOffline }: AccessKeyParam): Promise<AccessKey> => {


### PR DESCRIPTION
This PR adds an array to PrismaBuilderParameters settings, so the ID and UNIQUE properties used by prisma is "mounted" correctly