### PR TITLE
[FEAT] - create function to switch variables codes to variables values

### DIFF
--- a/__tests__/string/formatters.test.ts
+++ b/__tests__/string/formatters.test.ts
@@ -51,17 +51,6 @@ describe('dynamicVariableSwitcher', () => {
       returnedString: 'digosw@gmail.com'
     },
     {
-      inputString: '{{email}}',
-      dynamicVariables: {
-        nome_de_contato: 'Marcos',
-        cpf: '000.000.000-00',
-        email: 'digosw@gmail.com',
-        teste: 'teste',
-        outraString: 'OLHA QUE LEGAL!!!111ONZE!1'
-      },
-      returnedString: 'digosw@gmail.com'
-    },
-    {
       inputString: '{{email}}{{teste}}{{teste2}}',
       dynamicVariables: {
         nome_de_contato: 'Marcos',

--- a/__tests__/string/formatters.test.ts
+++ b/__tests__/string/formatters.test.ts
@@ -1,4 +1,4 @@
-import { capitalizeFirstLetter, kebabCaseToCamelCase, removeSpecialCharacters } from '../../src/string'
+import { capitalizeFirstLetter, kebabCaseToCamelCase, removeSpecialCharacters, dynamicVariableSwitcher } from '../../src/string'
 
 describe('capitalizeFirstLetter', () => {
   const data = [{ input: 'teste', output: 'Teste' }, { input: 'TESTE', output: 'TESTE' }, { input: 'alan Reno Neves', output: 'Alan Reno Neves' }]
@@ -23,5 +23,69 @@ describe('removeSpecialCharacters', () => {
 
   test.each(data)('Should return string without special characters', (param) => {
     expect(removeSpecialCharacters(param.input)).toBe(param.output)
+  })
+})
+
+describe('dynamicVariableSwitcher', () => {
+  const data = [
+    {
+      inputString: '{{nome_de_contato}}, {{cpf}}, sua documentação esta pronta',
+      dynamicVariables: {
+        nome_de_contato: 'Marcos',
+        cpf: '063.091.879-10',
+        email: 'digosw@gmail.com',
+        teste: 'teste',
+        outraString: 'OLHA QUE LEGAL!!!111ONZE!1'
+      },
+      returnedString: 'Marcos, 063.091.879-10, sua documentação esta pronta'
+    },
+    {
+      inputString: '{{email}}',
+      dynamicVariables: {
+        nome_de_contato: 'Marcos',
+        cpf: '063.091.879-10',
+        email: 'digosw@gmail.com',
+        teste: 'teste',
+        outraString: 'OLHA QUE LEGAL!!!111ONZE!1'
+      },
+      returnedString: 'digosw@gmail.com'
+    },
+    {
+      inputString: '{{email}}',
+      dynamicVariables: {
+        nome_de_contato: 'Marcos',
+        cpf: '063.091.879-10',
+        email: 'digosw@gmail.com',
+        teste: 'teste',
+        outraString: 'OLHA QUE LEGAL!!!111ONZE!1'
+      },
+      returnedString: 'digosw@gmail.com'
+    },
+    {
+      inputString: '{{email}}{{teste}}{{teste2}}',
+      dynamicVariables: {
+        nome_de_contato: 'Marcos',
+        cpf: '063.091.879-10',
+        email: 'digosw@gmail.com',
+        teste: 'teste',
+        outraString: 'OLHA QUE LEGAL!!!111ONZE!1'
+      },
+      returnedString: 'digosw@gmail.comteste'
+    },
+    {
+      inputString: '{{outraString}} {{testes}}',
+      dynamicVariables: {
+        nome_de_contato: 'Marcos',
+        cpf: '063.091.879-10',
+        email: 'digosw@gmail.com',
+        teste: 'teste',
+        outraString: 'OLHA QUE LEGAL!!!111ONZE!1'
+      },
+      returnedString: 'OLHA QUE LEGAL!!!111ONZE!1 '
+    }
+  ]
+
+  test.each(data)('Should switch every regex match with its matching dynamicVariable', (param) => {
+    expect(dynamicVariableSwitcher(param.inputString, param.dynamicVariables)).toBe(param.returnedString)
   })
 })

--- a/__tests__/string/formatters.test.ts
+++ b/__tests__/string/formatters.test.ts
@@ -32,18 +32,18 @@ describe('dynamicVariableSwitcher', () => {
       inputString: '{{nome_de_contato}}, {{cpf}}, sua documentação esta pronta',
       dynamicVariables: {
         nome_de_contato: 'Marcos',
-        cpf: '063.091.879-10',
+        cpf: '000.000.000-00',
         email: 'digosw@gmail.com',
         teste: 'teste',
         outraString: 'OLHA QUE LEGAL!!!111ONZE!1'
       },
-      returnedString: 'Marcos, 063.091.879-10, sua documentação esta pronta'
+      returnedString: 'Marcos, 000.000.000-00, sua documentação esta pronta'
     },
     {
       inputString: '{{email}}',
       dynamicVariables: {
         nome_de_contato: 'Marcos',
-        cpf: '063.091.879-10',
+        cpf: '000.000.000-00',
         email: 'digosw@gmail.com',
         teste: 'teste',
         outraString: 'OLHA QUE LEGAL!!!111ONZE!1'
@@ -54,7 +54,7 @@ describe('dynamicVariableSwitcher', () => {
       inputString: '{{email}}',
       dynamicVariables: {
         nome_de_contato: 'Marcos',
-        cpf: '063.091.879-10',
+        cpf: '000.000.000-00',
         email: 'digosw@gmail.com',
         teste: 'teste',
         outraString: 'OLHA QUE LEGAL!!!111ONZE!1'
@@ -65,7 +65,7 @@ describe('dynamicVariableSwitcher', () => {
       inputString: '{{email}}{{teste}}{{teste2}}',
       dynamicVariables: {
         nome_de_contato: 'Marcos',
-        cpf: '063.091.879-10',
+        cpf: '000.000.000-00',
         email: 'digosw@gmail.com',
         teste: 'teste',
         outraString: 'OLHA QUE LEGAL!!!111ONZE!1'
@@ -76,7 +76,7 @@ describe('dynamicVariableSwitcher', () => {
       inputString: '{{outraString}} {{testes}}',
       dynamicVariables: {
         nome_de_contato: 'Marcos',
-        cpf: '063.091.879-10',
+        cpf: '000.000.000-00',
         email: 'digosw@gmail.com',
         teste: 'teste',
         outraString: 'OLHA QUE LEGAL!!!111ONZE!1'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "adapcon-utils-js",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adapcon-utils-js",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "Utils library for Javascript",
   "keywords": [],
   "author": {

--- a/src/string/formatters.ts
+++ b/src/string/formatters.ts
@@ -3,3 +3,13 @@ export const capitalizeFirstLetter = (str: string): string => str.charAt(0).toUp
 export const kebabCaseToCamelCase = (str: string): string => str.replace(/-./g, x => x[1].toUpperCase())
 
 export const removeSpecialCharacters = (str: string): string => str.replace(/[^a-zA-Z0-9 ]/g, '')
+
+export const dynamicVariableSwitcher = (
+  textContainingVariables: string,
+  dynamicVariables: { [key: string]: string },
+  searchRegexPattern = /{{[A-Za-z0-9_]+}}/g,
+  variableCleanerPattern = /[{}]/g
+) => textContainingVariables.replace(searchRegexPattern, match => {
+  const dynamicVariableKey = match.replace(variableCleanerPattern, '')
+  return dynamicVariables[dynamicVariableKey] || ''
+})


### PR DESCRIPTION
This PR creates a function that receives a string and an object containing keys and values and insert values into the original string. It also could receive other two params: the regex to find the variable in the string provided and the regex to clean the variable itself. These two params have a default value: the first will lookup the provided string for anything like these patterns:
{{somevalue}}, {{some_value}}. The second will clear the variable of its curly brackets. (so, the found {{somevalue}} will become somevalue.

The use is very simple: 
Given a string like "{{email}}", the function will match the "variable code" ({{email}}) and try to match it with the values existing in the object; If the object has that key, the variable code will be switched to the key's value;