### PR TITLE
[FIX] - [BS-26] enable body to be a stringfied json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "adapcon-utils-js",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adapcon-utils-js",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Utils library for Javascript",
   "keywords": [],
   "author": {

--- a/src/lambda/interfaces.ts
+++ b/src/lambda/interfaces.ts
@@ -14,7 +14,7 @@ export interface lambdaParameters {
   functionName: string
   invocationType?: string
   headers?: {[key: string]: any}
-  body?: {[key: string]: any}
+  body?: {[key: string]: any} | string
   pathParameters?: {[key: string]: any}
   queryStringParameters?: {[key: string]: any}
   isOffline?: boolean


### PR DESCRIPTION
This PR enables the body prop of a invoke lambda to be a stringfied json.

We're already using the ms-utils SDK with a stringfied json as the body, but... following the steps, I came across this and decided to fix it