### PR TITLE
feat: accept headers on lambdaRest and formatResponse

### DIFF
--- a/__tests__/lambda/formatters.test.ts
+++ b/__tests__/lambda/formatters.test.ts
@@ -8,6 +8,20 @@ describe('invoke', () => {
     })).toEqual({ body: { error: 'Invalid Session' }, status: 401 })
   })
 
+  it('Should returns response formatted with headers', () => {
+    expect(formattedResponse({
+      StatusCode: 200,
+      Payload: '{"headers":"{\\"total-count\\":\\"20\\"}"}'
+    })).toEqual({ headers: { 'total-count': '20' }, status: 200, body: {} })
+  })
+
+  it('Should returns response formatted with headers and body', () => {
+    expect(formattedResponse({
+      StatusCode: 200,
+      Payload: '{"headers": "{\\"total-count\\":\\"20\\"}","body": "{\\"name\\":\\"John Doe\\"}"}'
+    })).toEqual({ headers: { 'total-count': '20' }, status: 200, body: { name: 'John Doe' } })
+  })
+
   it('Should returns response formatted with status code 200', () => {
     expect(formattedResponse({
       StatusCode: 200,

--- a/__tests__/lambda/lambdaResponses.test.ts
+++ b/__tests__/lambda/lambdaResponses.test.ts
@@ -35,11 +35,23 @@ describe('lambdaResp', () => {
         statusCode: 404,
         body: 'not found!'
       }
+    },
+    {
+      input: {
+        statusCode: 200,
+        body: '',
+        headers: { 'total-count': 42069 }
+      },
+      output: {
+        statusCode: 200,
+        body: '',
+        headers: { 'total-count': 42069 }
+      }
     }
   ]
 
   test.each(data)('Should return an response Object, with statusCode and body props', (param) => {
-    expect(lambdaResp(param.input.statusCode, param.input.body)).toStrictEqual(param.output)
+    expect(lambdaResp(param.input.statusCode, param.input.body, param.input.headers)).toStrictEqual(param.output)
   })
 })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "adapcon-utils-js",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adapcon-utils-js",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "description": "Utils library for Javascript",
   "keywords": [],
   "author": {

--- a/src/lambda/formatters.ts
+++ b/src/lambda/formatters.ts
@@ -2,12 +2,13 @@ import jsonBigInt from 'json-bigint'
 
 import { isObject } from '../object'
 
-export const formattedResponse = ({ StatusCode, Payload }: { StatusCode?: any, Payload?: any }): object => {
+export const formattedResponse = ({ StatusCode, Payload }: { StatusCode?: number, Payload?: any }): object => {
   const payloadFormatted = JSON.parse(Payload || '{}')
 
   return {
     status: payloadFormatted.statusCode || StatusCode,
-    body: payloadFormatted.body ? JSON.parse(payloadFormatted.body) : {}
+    body: payloadFormatted.body ? JSON.parse(payloadFormatted.body) : {},
+    ...(payloadFormatted.headers ? { headers: JSON.parse(payloadFormatted.headers) } : null)
   }
 }
 

--- a/src/lambda/interfaces.ts
+++ b/src/lambda/interfaces.ts
@@ -7,6 +7,10 @@ export interface Error {
   message?: string
 }
 
+export type Headers = {
+  [header: string]: string | number | boolean
+}
+
 export interface lambdaParameters {
   port?: string
   region?: string

--- a/src/lambda/lambdaResponses.ts
+++ b/src/lambda/lambdaResponses.ts
@@ -1,11 +1,12 @@
 import { isNumber } from '../number'
 import { objToStr } from '../object'
 import { ProxyResult } from 'aws-lambda'
-import type { Error } from './interfaces'
+import type { Error, Headers } from './interfaces'
 
-export const lambdaResp = (statusCode: number, body?: object | string): ProxyResult => ({
+export const lambdaResp = (statusCode: number, body?: object | string, headers?: Headers): ProxyResult => ({
   statusCode,
-  ...(body ? { body: objToStr(body) } : { body: '' })
+  ...(body ? { body: objToStr(body) } : { body: '' }),
+  ...(headers ? { headers } : null)
 })
 
 export const lambdaRespError = (err: Error): ProxyResult => {


### PR DESCRIPTION
### Description 
Changing lambdaResp and formatResponse functions so they accept headers and return them to the final response.
 
closes #192 