### PR TITLE
fix: does not parse json that is already a js object

### DIFF
--- a/__tests__/lambda/formatters.test.ts
+++ b/__tests__/lambda/formatters.test.ts
@@ -11,14 +11,14 @@ describe('invoke', () => {
   it('Should returns response formatted with headers', () => {
     expect(formattedResponse({
       StatusCode: 200,
-      Payload: '{"headers":"{\\"total-count\\":\\"20\\"}"}'
+      Payload: '{"headers": {"total-count":"20"}}'
     })).toEqual({ headers: { 'total-count': '20' }, status: 200, body: {} })
   })
 
   it('Should returns response formatted with headers and body', () => {
     expect(formattedResponse({
       StatusCode: 200,
-      Payload: '{"headers": "{\\"total-count\\":\\"20\\"}","body": "{\\"name\\":\\"John Doe\\"}"}'
+      Payload: '{"headers": {"total-count":"20"},"body": "{\\"name\\":\\"John Doe\\"}"}'
     })).toEqual({ headers: { 'total-count': '20' }, status: 200, body: { name: 'John Doe' } })
   })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "adapcon-utils-js",
-  "version": "0.16.3",
+  "version": "0.16.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adapcon-utils-js",
-  "version": "0.16.3",
+  "version": "0.16.4",
   "description": "Utils library for Javascript",
   "keywords": [],
   "author": {

--- a/src/lambda/formatters.ts
+++ b/src/lambda/formatters.ts
@@ -8,7 +8,7 @@ export const formattedResponse = ({ StatusCode, Payload }: { StatusCode?: number
   return {
     status: payloadFormatted.statusCode || StatusCode,
     body: payloadFormatted.body ? JSON.parse(payloadFormatted.body) : {},
-    ...(payloadFormatted.headers ? { headers: JSON.parse(payloadFormatted.headers) } : null)
+    ...(payloadFormatted.headers ? { headers: payloadFormatted.headers } : null)
   }
 }
 


### PR DESCRIPTION
### Description
Fixing conversion of already js object (header) with JSON.parse (unnecessary)