### PR TITLE
[FIX] lambda get parameters

### DIFF
--- a/__tests__/lambda/lambdaGetParameters.test.ts
+++ b/__tests__/lambda/lambdaGetParameters.test.ts
@@ -29,6 +29,24 @@ describe('lambdaGetParameters', () => {
           auth: 'xyz',
           app: 'theAppId'
         },
+        queryStringParameters: null
+      },
+      eventParams: {
+        auth: 'pathParameters',
+        app: 'pathParameters',
+        date: 'queryStringParameters'
+      },
+      output: {
+        auth: 'xyz',
+        app: 'theAppId'
+      }
+    },
+    {
+      event: {
+        pathParameters: {
+          auth: 'xyz',
+          app: 'theAppId'
+        },
         queryParameters: {
           date: 1639423222426
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "adapcon-utils-js",
-  "version": "0.16.5",
+  "version": "0.16.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adapcon-utils-js",
-  "version": "0.16.5",
+  "version": "0.16.6",
   "description": "Utils library for Javascript",
   "keywords": [],
   "author": {

--- a/src/lambda/lambdaGetParameters.ts
+++ b/src/lambda/lambdaGetParameters.ts
@@ -3,17 +3,19 @@ export const lambdaGetParameters = (event: object, eventParams: object): { [key:
   const fedParams = {}
 
   for (const element in eventParams) {
-    const path: string = eventParams[element]
+    if (Object.prototype.hasOwnProperty.call(eventParams, element)) {
+      const path: string = eventParams[element]
 
-    if (path in event) {
-      const eventPathObject: object = event[path]
-      if (!eventPathObject) continue
-      const fedParam: any = path === 'body' ? eventPathObject : eventPathObject[element]
-      let paramKey: string = element
-      if (path === 'headers') {
-        paramKey = kebabCaseToCamelCase(element)
+      if (path in event) {
+        const eventPathObject: object = event[path]
+        if (!eventPathObject) continue
+        const fedParam: any = path === 'body' ? eventPathObject : eventPathObject[element]
+        let paramKey: string = element
+        if (path === 'headers') {
+          paramKey = kebabCaseToCamelCase(element)
+        }
+        fedParams[paramKey] = fedParam
       }
-      fedParams[paramKey] = fedParam
     }
   }
 

--- a/src/lambda/lambdaGetParameters.ts
+++ b/src/lambda/lambdaGetParameters.ts
@@ -2,20 +2,18 @@ import { kebabCaseToCamelCase } from './../string/formatters'
 export const lambdaGetParameters = (event: object, eventParams: object): { [key: string]: any } => {
   const fedParams = {}
 
-  for (const element in eventParams) {
-    if (Object.prototype.hasOwnProperty.call(eventParams, element)) {
-      const path: string = eventParams[element]
+  for (const element of Object.keys(eventParams)) {
+    const path: string = eventParams[element]
 
-      if (path in event) {
-        const eventPathObject: object = event[path]
-        if (!eventPathObject) continue
-        const fedParam: any = path === 'body' ? eventPathObject : eventPathObject[element]
-        let paramKey: string = element
-        if (path === 'headers') {
-          paramKey = kebabCaseToCamelCase(element)
-        }
-        fedParams[paramKey] = fedParam
+    if (path in event) {
+      const eventPathObject: object = event[path]
+      if (!eventPathObject) continue
+      const fedParam: any = path === 'body' ? eventPathObject : eventPathObject[element]
+      let paramKey: string = element
+      if (path === 'headers') {
+        paramKey = kebabCaseToCamelCase(element)
       }
+      fedParams[paramKey] = fedParam
     }
   }
 

--- a/src/lambda/lambdaGetParameters.ts
+++ b/src/lambda/lambdaGetParameters.ts
@@ -7,6 +7,7 @@ export const lambdaGetParameters = (event: object, eventParams: object): { [key:
 
     if (path in event) {
       const eventPathObject: object = event[path]
+      if (!eventPathObject) continue
       const fedParam: any = path === 'body' ? eventPathObject : eventPathObject[element]
       let paramKey: string = element
       if (path === 'headers') {


### PR DESCRIPTION
This PR handles the possibility of trying to get a parameter from a certain location (let's say: queryStringParameters) and that location is inexistent in event params