### PR TITLE
fix: change type import from api gateway proxy types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "adapcon-utils-js",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "adapcon-utils-js",
-      "version": "1.1.5",
+      "version": "1.1.6",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.496.0",
         "@aws-sdk/client-lambda": "^3.496.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adapcon-utils-js",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Utils library for Javascript",
   "keywords": [],
   "author": {

--- a/src/lambda/crudHandler.ts
+++ b/src/lambda/crudHandler.ts
@@ -1,8 +1,8 @@
 import { lambdaGetParameters } from './lambdaGetParameters'
-import type { APIGatewayEvent } from 'aws-lambda'
 import { error } from '../error'
 import { getDefaultResponse, HttpNames } from '../http'
 import { CrudInputParams } from '../'
+import type { APIGatewayEvent } from 'aws-lambda/trigger/api-gateway-proxy'
 
 export const lambdaCrudHandler = (
   event: APIGatewayEvent,

--- a/src/lambda/lambdaResponses.ts
+++ b/src/lambda/lambdaResponses.ts
@@ -1,6 +1,6 @@
+import type { ProxyResult } from 'aws-lambda/trigger/api-gateway-proxy'
 import { isNumber } from '../number'
 import { objToStr } from '../object'
-import type { ProxyResult } from 'aws-lambda'
 import type { Error, Headers } from './interfaces'
 
 export const lambdaResp = (statusCode: number, body?: object | string, headers?: Headers): ProxyResult => ({


### PR DESCRIPTION
Fixing type imports from api gateway proxy types. It was breaking simplificamais-ms-utils build.
I used `npm link` and it worked on both, simplificamais-ms-utils and amc-ms-utils.

Before:
![image](https://github.com/Adapcon/adapcon-utils-js/assets/51389447/69c405ec-c8bd-462b-a665-e381ef70ceaf)
