### PR TITLE
[FIX] secrets manager

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "adapcon-utils-js",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "adapcon-utils-js",
-      "version": "1.1.8",
+      "version": "1.1.9",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.496.0",
         "@aws-sdk/client-lambda": "^3.496.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "adapcon-utils-js",
-  "version": "1.1.9",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "adapcon-utils-js",
-      "version": "1.1.9",
+      "version": "1.2.0",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.496.0",
         "@aws-sdk/client-lambda": "^3.496.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adapcon-utils-js",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "Utils library for Javascript",
   "keywords": [],
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adapcon-utils-js",
-  "version": "1.1.9",
+  "version": "1.2.0",
   "description": "Utils library for Javascript",
   "keywords": [],
   "author": {

--- a/src/secretsManager/secretManager.ts
+++ b/src/secretsManager/secretManager.ts
@@ -11,10 +11,10 @@ export const SecretManager = {
     if (!secret) throw new Error('Secret not found!')
     if (!secret.SecretString) throw new Error('Secret without a value!')
 
-    return JSON.parse(secret.SecretString)
+    return secret as any as AccessKey
   },
 
-  getAccessKey: async ({ region, serviceSecretArn: secretId, isOffline }: AccessKeyParam): Promise<AccessKey> => {
+  getAccessKey: async ({ region, serviceSecretArn: secretId, isOffline }: AccessKeyParam): Promise<AccessKey|{}> => {
     return (secretId && !isOffline)
       ? await SecretManager.getValue({
         region,

--- a/src/secretsManager/secretManager.ts
+++ b/src/secretsManager/secretManager.ts
@@ -14,7 +14,7 @@ export const SecretManager = {
     return secret as unknown as AccessKey
   },
 
-  getAccessKey: async ({ region, serviceSecretArn: secretId, isOffline }: AccessKeyParam): Promise<AccessKey|{}> => {
+  getAccessKey: async ({ region, serviceSecretArn: secretId, isOffline }: AccessKeyParam): Promise<AccessKey|object> => {
     return (secretId && !isOffline)
       ? await SecretManager.getValue({
         region,

--- a/src/secretsManager/secretManager.ts
+++ b/src/secretsManager/secretManager.ts
@@ -11,7 +11,7 @@ export const SecretManager = {
     if (!secret) throw new Error('Secret not found!')
     if (!secret.SecretString) throw new Error('Secret without a value!')
 
-    return secret as any as AccessKey
+    return secret as unknown as AccessKey
   },
 
   getAccessKey: async ({ region, serviceSecretArn: secretId, isOffline }: AccessKeyParam): Promise<AccessKey|{}> => {


### PR DESCRIPTION
PR corrige um problema no get de SecretsManager.
No novo aws-sdk a parada ja vem pronta pra ser usada, sem necessidade de parsear