### PR TITLE
ci: dynamic versioning on release package.

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -4,8 +4,7 @@ on:
   push:
     branches:
       - 'master'
-      - '^v-\d+\.\d+\.\d+$' # v-0.0.0
-
+      - '^v-\d+\.\d+(\.\d+)?$' # v-0.0.0, v-0.0
 
 jobs:
   publish:
@@ -29,8 +28,9 @@ jobs:
           if [[ "${{ steps.get-branch.outputs.branch }}" == "master" ]]; then
             echo "::set-output name=tag::latest"
           else
-            branch_name=$(echo "${{ steps.get-branch.outputs.branch }}" | sed 's/^v-//')
-            echo "::set-output name=tag::$branch_name"
+            version=$(jq -r '.version' package.json)
+            branch_name=$(echo "${{ steps.branch-name.outputs.branch }}" | sed 's/^v-//')
+            echo "::set-output name=tag::${branch_name:-$version}"
           fi
 
       - name: npm install

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -2,7 +2,10 @@ name: CI
 
 on:
   push:
-    branches: master
+    branches:
+      - 'master'
+      - '^v-\d+\.\d+\.\d+$' # v-0.0.0
+
 
 jobs:
   publish:
@@ -16,6 +19,20 @@ jobs:
         with:
           node-version: 20
 
+      - name: Get branch name
+        id: get-branch
+        run: echo "::set-output name=branch::${GITHUB_REF#refs/heads/}"
+
+      - name: Get release tag
+        id: get-tag
+        run: |
+          if [[ "${{ steps.get-branch.outputs.branch }}" == "master" ]]; then
+            echo "::set-output name=tag::latest"
+          else
+            branch_name=$(echo "${{ steps.get-branch.outputs.branch }}" | sed 's/^v-//')
+            echo "::set-output name=tag::$branch_name"
+          fi
+
       - name: npm install
         run: npm ci
 
@@ -26,3 +43,4 @@ jobs:
         uses: JS-DevTools/npm-publish@v1
         with:
           token: ${{ secrets.NPM_TOKEN }}
+          tag: ${{ steps.get-tag.outputs.tag }}


### PR DESCRIPTION
Get Branch step is used to get the current branch name and use it on the Get Tag step, this step is used to set the npm tag when deploying the package.

By using this new job we can still maintain older versions of the package, instead of always realising the latest updates.

For example: this package is currently on version 1.2.0 and we have a service that uses the 0.48.x version. In that service, I cannot update for 1.2.0 cause it has breaking changes, like nodejs runtime and package imports. So to update/fix something on this package I will need, also, to upgrade my whole service to fit the latest changes on this package.

With these changes, we still can change maintain 0.48.x, 1.0.x, versions without pushing that to master. That way master will always contain the latest release.
We do need to keep in mind that the bug fixes will need to be implemented on the version we need, like 0.48.x, and on the master branch, and deploy it on, both, latest and desired version. 