### PR TITLE
Feat/custom errors class based

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ dist
 coverage
 .env
 build
+
+.tool-versions

--- a/__tests__/date/date.test.ts
+++ b/__tests__/date/date.test.ts
@@ -76,4 +76,3 @@ describe('getDiffDays', () => {
     expect(getDiffDays(param.date)).toBe(param.output)
   })
 })
-

--- a/__tests__/entitySchema/index.test.ts
+++ b/__tests__/entitySchema/index.test.ts
@@ -1,4 +1,4 @@
-import { EntitySchema } from '../../src/entitySchema';
+import { EntitySchema } from '../../src/entitySchema'
 
 describe('assembleEntitySchema', () => {
   const validDefaultsObjects = [
@@ -6,15 +6,15 @@ describe('assembleEntitySchema', () => {
       solicitation: {
         appId: true,
         jsonData: {
-          address: true,
-        },
+          address: true
+        }
       },
       entitySchema: {
         appId: {
           type: 'string',
           occult: false,
           required: true,
-          label: 'Portal',
+          label: 'Portal'
         },
         jsonData: {
           type: 'object',
@@ -26,7 +26,7 @@ describe('assembleEntitySchema', () => {
               type: 'string',
               occult: false,
               required: true,
-              label: 'Ocorrência',
+              label: 'Ocorrência'
             },
             address: {
               type: 'object',
@@ -38,17 +38,17 @@ describe('assembleEntitySchema', () => {
                   type: 'string',
                   occult: false,
                   required: true,
-                  label: 'Estado',
+                  label: 'Estado'
                 },
                 city: {
                   type: 'string',
                   occult: false,
                   required: true,
-                  label: 'Cidade',
-                },
-              },
-            },
-          },
+                  label: 'Cidade'
+                }
+              }
+            }
+          }
         },
         test: {
           type: 'array',
@@ -59,16 +59,16 @@ describe('assembleEntitySchema', () => {
             type: 'string',
             occult: false,
             required: true,
-            label: 'Ocorrência',
-          },
-        },
+            label: 'Ocorrência'
+          }
+        }
       },
       returnExpected: {
         appId: {
           type: 'string',
           occult: false,
           required: true,
-          label: 'Portal',
+          label: 'Portal'
         },
         jsonData: {
           type: 'object',
@@ -86,46 +86,46 @@ describe('assembleEntitySchema', () => {
                   type: 'string',
                   occult: false,
                   required: true,
-                  label: 'Estado',
+                  label: 'Estado'
                 },
                 city: {
                   type: 'string',
                   occult: false,
                   required: true,
-                  label: 'Cidade',
-                },
-              },
-            },
-          },
-        },
-      },
+                  label: 'Cidade'
+                }
+              }
+            }
+          }
+        }
+      }
     },
     {
       solicitation: {
-        jsonData: true,
+        jsonData: true
       },
       entitySchema: {
         appId: {
           type: 'string',
           occult: false,
           required: true,
-          label: 'Portal',
-        },
+          label: 'Portal'
+        }
       },
-      returnExpected: {},
+      returnExpected: {}
     },
     {
       solicitation: {
-        appId: true,
+        appId: true
       },
       entitySchema: undefined,
-      returnExpected: {},
+      returnExpected: {}
     },
     {
       solicitation: {
         test: {
-          children1: true,
-        },
+          children1: true
+        }
       },
       entitySchema: {
         test: {
@@ -138,51 +138,51 @@ describe('assembleEntitySchema', () => {
               type: 'string',
               occult: false,
               required: true,
-              label: 'teste',
+              label: 'teste'
             },
             children2: {
               type: 'string',
               occult: false,
               required: true,
-              label: 'teste',
-            },
-          },
-        },
+              label: 'teste'
+            }
+          }
+        }
       },
       returnExpected: {
         test: {
           contentArray: {
             children1: {
-              label: "teste",
+              label: 'teste',
               occult: false,
               required: true,
-              type: "string",
+              type: 'string'
             },
             children2: {
-              label: "teste",
+              label: 'teste',
               occult: false,
               required: true,
-              type: "string",
-            },
+              type: 'string'
+            }
           },
           contentObject: {
             children1: {
-              label: "teste",
+              label: 'teste',
               occult: false,
               required: true,
-              type: "string",
-            },
+              type: 'string'
+            }
           },
-          label: "teste",
+          label: 'teste',
           occult: false,
           required: true,
-          type: "array",
-        },
-      },
-    },
-  ];
+          type: 'array'
+        }
+      }
+    }
+  ]
 
   test.each(validDefaultsObjects)('should returns validation of the provided specific entity schema', ({ solicitation, entitySchema, returnExpected }) => {
-    expect(EntitySchema.assembleEntitySchema(solicitation, entitySchema)).toEqual(returnExpected);
-  });
-});
+    expect(EntitySchema.assembleEntitySchema(solicitation, entitySchema)).toEqual(returnExpected)
+  })
+})

--- a/__tests__/error/index.test.ts
+++ b/__tests__/error/index.test.ts
@@ -1,11 +1,11 @@
-import { error } from '../../src/error';
+import { error } from '../../src/error'
 
 describe('error', () => {
   it('Should format error with a error object', () => {
-    expect(error(400, { id: undefined })).toEqual({ statusCode: 400, error: { id: undefined } });
-  });
+    expect(error(400, { id: undefined })).toEqual({ statusCode: 400, error: { id: undefined } })
+  })
 
   it('Should format error with a error string', () => {
-    expect(error(400, 'Incorrect id value')).toEqual({ statusCode: 400, message: 'Incorrect id value' });
-  });
-});
+    expect(error(400, 'Incorrect id value')).toEqual({ statusCode: 400, message: 'Incorrect id value' })
+  })
+})

--- a/__tests__/lambda/lambdaService.test.ts
+++ b/__tests__/lambda/lambdaService.test.ts
@@ -18,7 +18,7 @@ describe('invoke', () => {
      })).resolves.toEqual({status: 400, body: { code:  'undefined' }});
 
      */
-  });
+  })
 
   it('Should returns the function invoked with error', async () => {
     /**
@@ -35,7 +35,7 @@ describe('invoke', () => {
       isOffline: false,
     })).rejects.toBeTruthy();
     **/
-  });
+  })
 
   it('Should returns error to invoke without optional properties', async () => {
     /**
@@ -44,5 +44,5 @@ describe('invoke', () => {
       functionName: 'authenticate-api-generalValidateSession',
     })).rejects.toBeTruthy();
     **/
-  });
-});
+  })
+})

--- a/__tests__/s3/formatters.test.ts
+++ b/__tests__/s3/formatters.test.ts
@@ -25,6 +25,4 @@ describe('streamToString', () => {
     const result = await streamToString(readable)
     expect(result).toEqual(jsonString)
   })
-
-
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "adapcon-utils-js",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "adapcon-utils-js",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.496.0",
         "@aws-sdk/client-lambda": "^3.496.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adapcon-utils-js",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Utils library for Javascript",
   "keywords": [],
   "author": {

--- a/src/entitySchema/index.ts
+++ b/src/entitySchema/index.ts
@@ -1,24 +1,25 @@
 export const EntitySchema = {
-  assembleEntitySchema(solicitation: any, entitySchema: any): object {
-  const defaultObject = {};
-  const properties = Object.keys(solicitation);
+  assembleEntitySchema (solicitation: any, entitySchema: any): object {
+    const defaultObject = {}
+    const properties = Object.keys(solicitation)
 
-  properties.forEach(key => {
-    if (entitySchema === undefined) return;
-    const haveChildren = typeof solicitation[key] === 'object';
-    const property = entitySchema[key];
+    properties.forEach(key => {
+      if (entitySchema === undefined) return
+      const haveChildren = typeof solicitation[key] === 'object'
+      const property = entitySchema[key]
 
-    if (property === undefined) return;
+      if (property === undefined) return
 
-    if (haveChildren) {
-      defaultObject[key] = {
-        ...property,
-        contentObject: {
-          ...EntitySchema.assembleEntitySchema(solicitation[key], property.contentObject || property.contentArray),
-        },
-      };
-    } else defaultObject[key] = property;
-  });
+      if (haveChildren) {
+        defaultObject[key] = {
+          ...property,
+          contentObject: {
+            ...EntitySchema.assembleEntitySchema(solicitation[key], property.contentObject || property.contentArray)
+          }
+        }
+      } else defaultObject[key] = property
+    })
 
-  return defaultObject;
-}}
+    return defaultObject
+  }
+}

--- a/src/error/customErrors.test.ts
+++ b/src/error/customErrors.test.ts
@@ -1,0 +1,174 @@
+import { HttpStatuses } from ".."
+import * as Errors from "./customErrors"
+
+
+describe("InternalError", () => {
+  it("should return a ConnectionError with correct message and statusCode", () => {
+    const error = new Errors.InternalError(new Error("throwing error"))
+
+    expect(error).toMatchObject({
+     message: "throwing error",
+     statusCode: HttpStatuses.internalError
+   })
+  })
+
+  it("should return string containing correct items on toString() call", () => {
+    const error = new Errors.InternalError(new Error("throwing error"))
+
+    expect(error.toString()).toContain(`Internal Error: throwing error`)
+  })
+
+  it("should return correct lambdaResponse on toLambdaResponse() call", () => {
+    const error = new Errors.InternalError(new Error("throwing error"))
+
+    expect(error.toLambdaResponse()).toMatchObject({
+      statusCode: HttpStatuses.internalError,
+      body: JSON.stringify({ message: "throwing error" })
+    })
+  })
+})
+
+describe("IntegrationError", () => {
+  it("should return a IntegrationError with correct message and statusCode", () => {
+    const integrationName = "microservice1"
+    const error = new Errors.IntegrationError(integrationName)
+
+    expect(error).toMatchObject({
+      message: `Could not integration with ${integrationName}`,
+      statusCode: HttpStatuses.integrationError
+    })
+  })
+
+  it("IntegrationError toString()", () => {
+    const integrationName = "microservice1"
+    const error = new Errors.IntegrationError(integrationName)
+
+    expect(error.toString()).toContain(`Integration Error: Could not integration with ${integrationName}`)
+  })
+
+  it("should return correct lambdaResponse on toLambdaResponse() call", () => {
+    const integrationName = "microservice1"
+    const error = new Errors.IntegrationError(integrationName)
+
+    expect(error.toLambdaResponse()).toMatchObject({
+      statusCode: HttpStatuses.integrationError,
+      body: JSON.stringify({ message: `Could not integration with ${integrationName}` })
+    })
+  })
+
+  it("should return a IntegrationError with correct message, statusCode, and customError message", () => {
+    const integrationName = "microservice1"
+    const customMessage = "microservice1 is offline"
+    const error = new Errors.IntegrationError(integrationName, customMessage)
+
+    expect(error).toMatchObject({
+      message: customMessage,
+      statusCode: HttpStatuses.integrationError,
+      customMessage
+    })
+  })
+
+  it("IntegrationError toString() with customError message", () => {
+    const integrationName = "microservice1"
+    const error = new Errors.IntegrationError(integrationName, "microservice1 is offline")
+
+    expect(error.toString()).toContain(`Integration Error: microservice1 is offline`)
+  })
+
+  it("should return correct lambdaResponse on toLambdaResponse() call with customError message", () => {
+    const integrationName = "microservice1"
+    const customMessage = "microservice1 is offline"
+    const error = new Errors.IntegrationError(integrationName, customMessage)
+
+    expect(error.toLambdaResponse()).toMatchObject({
+      statusCode: HttpStatuses.integrationError,
+      body: JSON.stringify({ message: customMessage })
+    })
+  })
+})
+
+describe("BadRequestError", () => {
+  it("should return a BadRequestError with correct message and statusCode", () => {
+    const errorMessage = "invalid appId"
+    const error = new Errors.BadRequestError(errorMessage)
+
+    expect(error).toMatchObject({
+      message: errorMessage,
+      statusCode: HttpStatuses.badRequest
+    })
+  })
+
+  it("should return string containing correct items on toString() call", () => {
+    const errorMessage = "invalid appId"
+    const error = new Errors.BadRequestError(errorMessage)
+
+    expect(error.toString()).toContain(`Bad Request Error: ${errorMessage}`)
+  })
+
+  it("should return correct lambdaResponse on toLambdaResponse() call", () => {
+    const errorMessage = "invalid appId"
+    const error = new Errors.BadRequestError(errorMessage)
+
+    expect(error.toLambdaResponse()).toMatchObject({
+      statusCode: HttpStatuses.badRequest,
+      body: JSON.stringify({ message: errorMessage })
+    })
+  })
+})
+
+describe("NotFoundError", () => {
+  it("should return a NotFoundError with correct message and statusCode", () => {
+    const errorMessage = "thing not found"
+    const error = new Errors.NotFoundError(errorMessage)
+
+    expect(error).toMatchObject({
+      message: errorMessage,
+      statusCode: HttpStatuses.notFound
+    })
+  })
+
+  it("should return string containing correct items on toString() call", () => {
+    const errorMessage = "thing not found"
+    const error = new Errors.NotFoundError(errorMessage)
+
+    expect(error.toString()).toContain(`Not Found Error: ${errorMessage}`)
+  })
+
+  it("should return correct lambdaResponse on toLambdaResponse() call", () => {
+    const errorMessage = "thing not found"
+    const error = new Errors.NotFoundError(errorMessage)
+
+    expect(error.toLambdaResponse()).toMatchObject({
+      statusCode: HttpStatuses.notFound,
+      body: JSON.stringify({ message: errorMessage })
+    })
+  })
+})
+describe("UnauthorizedError", () => {
+  it("should return a UnauthorizedError with correct message and statusCode", () => {
+    const errorMessage = "not enough permissions"
+    const error = new Errors.UnauthorizedError(errorMessage)
+
+    expect(error).toMatchObject({
+      message: errorMessage,
+      statusCode: HttpStatuses.unauthorized
+    })
+  })
+
+  it("should return string containing correct items on toString() call", () => {
+    const errorMessage = "not enough permissions"
+    const error = new Errors.UnauthorizedError(errorMessage)
+
+    expect(error.toString()).toContain(`Unauthorized Error: ${errorMessage}`)
+  })
+
+  it("should return correct lambdaResponse on toLambdaResponse() call", () => {
+    const errorMessage = "not enough permissions"
+    const error = new Errors.UnauthorizedError(errorMessage)
+
+    expect(error.toLambdaResponse()).toMatchObject({
+      statusCode: HttpStatuses.unauthorized,
+      body: JSON.stringify({ message: errorMessage })
+    })
+  })
+})

--- a/src/error/customErrors.test.ts
+++ b/src/error/customErrors.test.ts
@@ -1,5 +1,5 @@
 import { HttpStatuses } from '..'
-import { InternalError, BadRequestError, NotFoundError, IntegrationError, UnauthorizedError, } from './customErrors'
+import { InternalError, BadRequestError, NotFoundError, IntegrationError, UnauthorizedError } from './customErrors'
 
 describe('CustomError', () => {
   describe('InternalError', () => {

--- a/src/error/customErrors.test.ts
+++ b/src/error/customErrors.test.ts
@@ -1,38 +1,37 @@
-import { HttpStatuses } from ".."
-// skipcq: JS-C1003
-import * as Errors from "./customErrors"
+import { HttpStatuses } from '..'
+import { InternalError, BadRequestError, NotFoundError, IntegrationError, UnauthorizedError, } from './customErrors'
 
-describe("CustomError", () => {
-  describe("InternalError", () => {
-    it("should return a ConnectionError with correct message and statusCode", () => {
-      const error = new Errors.InternalError(new Error("throwing error"))
+describe('CustomError', () => {
+  describe('InternalError', () => {
+    it('should return a ConnectionError with correct message and statusCode', () => {
+      const error = new InternalError(new Error('throwing error'))
 
       expect(error).toMatchObject({
-        message: "throwing error",
+        message: 'throwing error',
         statusCode: HttpStatuses.internalError
       })
     })
 
-    it("should return string containing correct items on toString() call", () => {
-      const error = new Errors.InternalError(new Error("throwing error"))
+    it('should return string containing correct items on toString() call', () => {
+      const error = new InternalError(new Error('throwing error'))
 
-      expect(error.toString()).toContain("Internal Error: throwing error")
+      expect(error.toString()).toContain('Internal Error: throwing error')
     })
 
-    it("should return correct lambdaResponse on toLambdaResponse() call", () => {
-      const error = new Errors.InternalError(new Error("throwing error"))
+    it('should return correct lambdaResponse on toLambdaResponse() call', () => {
+      const error = new InternalError(new Error('throwing error'))
 
       expect(error.toLambdaResponse()).toMatchObject({
         statusCode: HttpStatuses.internalError,
-        body: JSON.stringify({ message: "throwing error" })
+        body: JSON.stringify({ message: 'throwing error' })
       })
     })
   })
 
-  describe("IntegrationError", () => {
-    it("should return a IntegrationError with correct message and statusCode", () => {
-      const integrationName = "microservice1"
-      const error = new Errors.IntegrationError(integrationName)
+  describe('IntegrationError', () => {
+    it('should return a IntegrationError with correct message and statusCode', () => {
+      const integrationName = 'microservice1'
+      const error = new IntegrationError(integrationName)
 
       expect(error).toMatchObject({
         message: `Could not integration with ${integrationName}`,
@@ -40,16 +39,16 @@ describe("CustomError", () => {
       })
     })
 
-    it("IntegrationError toString()", () => {
-      const integrationName = "microservice1"
-      const error = new Errors.IntegrationError(integrationName)
+    it('IntegrationError toString()', () => {
+      const integrationName = 'microservice1'
+      const error = new IntegrationError(integrationName)
 
       expect(error.toString()).toContain(`Integration Error: Could not integration with ${integrationName}`)
     })
 
-    it("should return correct lambdaResponse on toLambdaResponse() call", () => {
-      const integrationName = "microservice1"
-      const error = new Errors.IntegrationError(integrationName)
+    it('should return correct lambdaResponse on toLambdaResponse() call', () => {
+      const integrationName = 'microservice1'
+      const error = new IntegrationError(integrationName)
 
       expect(error.toLambdaResponse()).toMatchObject({
         statusCode: HttpStatuses.integrationError,
@@ -57,10 +56,10 @@ describe("CustomError", () => {
       })
     })
 
-    it("should return a IntegrationError with correct message, statusCode, and customError message", () => {
-      const integrationName = "microservice1"
-      const customMessage = "microservice1 is offline"
-      const error = new Errors.IntegrationError(integrationName, customMessage)
+    it('should return a IntegrationError with correct message, statusCode, and customError message', () => {
+      const integrationName = 'microservice1'
+      const customMessage = 'microservice1 is offline'
+      const error = new IntegrationError(integrationName, customMessage)
 
       expect(error).toMatchObject({
         message: customMessage,
@@ -69,17 +68,17 @@ describe("CustomError", () => {
       })
     })
 
-    it("IntegrationError toString() with customError message", () => {
-      const integrationName = "microservice1"
-      const error = new Errors.IntegrationError(integrationName, "microservice1 is offline")
+    it('IntegrationError toString() with customError message', () => {
+      const integrationName = 'microservice1'
+      const error = new IntegrationError(integrationName, 'microservice1 is offline')
 
-      expect(error.toString()).toContain("Integration Error: microservice1 is offline")
+      expect(error.toString()).toContain('Integration Error: microservice1 is offline')
     })
 
-    it("should return correct lambdaResponse on toLambdaResponse() call with customError message", () => {
-      const integrationName = "microservice1"
-      const customMessage = "microservice1 is offline"
-      const error = new Errors.IntegrationError(integrationName, customMessage)
+    it('should return correct lambdaResponse on toLambdaResponse() call with customError message', () => {
+      const integrationName = 'microservice1'
+      const customMessage = 'microservice1 is offline'
+      const error = new IntegrationError(integrationName, customMessage)
 
       expect(error.toLambdaResponse()).toMatchObject({
         statusCode: HttpStatuses.integrationError,
@@ -88,10 +87,10 @@ describe("CustomError", () => {
     })
   })
 
-  describe("BadRequestError", () => {
-    it("should return a BadRequestError with correct message and statusCode", () => {
-      const errorMessage = "invalid appId"
-      const error = new Errors.BadRequestError(errorMessage)
+  describe('BadRequestError', () => {
+    it('should return a BadRequestError with correct message and statusCode', () => {
+      const errorMessage = 'invalid appId'
+      const error = new BadRequestError(errorMessage)
 
       expect(error).toMatchObject({
         message: errorMessage,
@@ -99,16 +98,16 @@ describe("CustomError", () => {
       })
     })
 
-    it("should return string containing correct items on toString() call", () => {
-      const errorMessage = "invalid appId"
-      const error = new Errors.BadRequestError(errorMessage)
+    it('should return string containing correct items on toString() call', () => {
+      const errorMessage = 'invalid appId'
+      const error = new BadRequestError(errorMessage)
 
       expect(error.toString()).toContain(`Bad Request Error: ${errorMessage}`)
     })
 
-    it("should return correct lambdaResponse on toLambdaResponse() call", () => {
-      const errorMessage = "invalid appId"
-      const error = new Errors.BadRequestError(errorMessage)
+    it('should return correct lambdaResponse on toLambdaResponse() call', () => {
+      const errorMessage = 'invalid appId'
+      const error = new BadRequestError(errorMessage)
 
       expect(error.toLambdaResponse()).toMatchObject({
         statusCode: HttpStatuses.badRequest,
@@ -117,10 +116,10 @@ describe("CustomError", () => {
     })
   })
 
-  describe("NotFoundError", () => {
-    it("should return a NotFoundError with correct message and statusCode", () => {
-      const errorMessage = "thing not found"
-      const error = new Errors.NotFoundError(errorMessage)
+  describe('NotFoundError', () => {
+    it('should return a NotFoundError with correct message and statusCode', () => {
+      const errorMessage = 'thing not found'
+      const error = new NotFoundError(errorMessage)
 
       expect(error).toMatchObject({
         message: errorMessage,
@@ -128,16 +127,16 @@ describe("CustomError", () => {
       })
     })
 
-    it("should return string containing correct items on toString() call", () => {
-      const errorMessage = "thing not found"
-      const error = new Errors.NotFoundError(errorMessage)
+    it('should return string containing correct items on toString() call', () => {
+      const errorMessage = 'thing not found'
+      const error = new NotFoundError(errorMessage)
 
       expect(error.toString()).toContain(`Not Found Error: ${errorMessage}`)
     })
 
-    it("should return correct lambdaResponse on toLambdaResponse() call", () => {
-      const errorMessage = "thing not found"
-      const error = new Errors.NotFoundError(errorMessage)
+    it('should return correct lambdaResponse on toLambdaResponse() call', () => {
+      const errorMessage = 'thing not found'
+      const error = new NotFoundError(errorMessage)
 
       expect(error.toLambdaResponse()).toMatchObject({
         statusCode: HttpStatuses.notFound,
@@ -145,10 +144,10 @@ describe("CustomError", () => {
       })
     })
   })
-  describe("UnauthorizedError", () => {
-    it("should return a UnauthorizedError with correct message and statusCode", () => {
-      const errorMessage = "not enough permissions"
-      const error = new Errors.UnauthorizedError(errorMessage)
+  describe('UnauthorizedError', () => {
+    it('should return a UnauthorizedError with correct message and statusCode', () => {
+      const errorMessage = 'not enough permissions'
+      const error = new UnauthorizedError(errorMessage)
 
       expect(error).toMatchObject({
         message: errorMessage,
@@ -156,16 +155,16 @@ describe("CustomError", () => {
       })
     })
 
-    it("should return string containing correct items on toString() call", () => {
-      const errorMessage = "not enough permissions"
-      const error = new Errors.UnauthorizedError(errorMessage)
+    it('should return string containing correct items on toString() call', () => {
+      const errorMessage = 'not enough permissions'
+      const error = new UnauthorizedError(errorMessage)
 
       expect(error.toString()).toContain(`Unauthorized Error: ${errorMessage}`)
     })
 
-    it("should return correct lambdaResponse on toLambdaResponse() call", () => {
-      const errorMessage = "not enough permissions"
-      const error = new Errors.UnauthorizedError(errorMessage)
+    it('should return correct lambdaResponse on toLambdaResponse() call', () => {
+      const errorMessage = 'not enough permissions'
+      const error = new UnauthorizedError(errorMessage)
 
       expect(error.toLambdaResponse()).toMatchObject({
         statusCode: HttpStatuses.unauthorized,

--- a/src/error/customErrors.test.ts
+++ b/src/error/customErrors.test.ts
@@ -2,173 +2,175 @@ import { HttpStatuses } from ".."
 import * as Errors from "./customErrors"
 
 
-describe("InternalError", () => {
-  it("should return a ConnectionError with correct message and statusCode", () => {
-    const error = new Errors.InternalError(new Error("throwing error"))
+describe("CustomError", () => {
+  describe("InternalError", () => {
+    it("should return a ConnectionError with correct message and statusCode", () => {
+      const error = new Errors.InternalError(new Error("throwing error"))
 
-    expect(error).toMatchObject({
-     message: "throwing error",
-     statusCode: HttpStatuses.internalError
-   })
-  })
-
-  it("should return string containing correct items on toString() call", () => {
-    const error = new Errors.InternalError(new Error("throwing error"))
-
-    expect(error.toString()).toContain(`Internal Error: throwing error`)
-  })
-
-  it("should return correct lambdaResponse on toLambdaResponse() call", () => {
-    const error = new Errors.InternalError(new Error("throwing error"))
-
-    expect(error.toLambdaResponse()).toMatchObject({
-      statusCode: HttpStatuses.internalError,
-      body: JSON.stringify({ message: "throwing error" })
+      expect(error).toMatchObject({
+        message: "throwing error",
+        statusCode: HttpStatuses.internalError
+      })
     })
-  })
-})
 
-describe("IntegrationError", () => {
-  it("should return a IntegrationError with correct message and statusCode", () => {
-    const integrationName = "microservice1"
-    const error = new Errors.IntegrationError(integrationName)
+    it("should return string containing correct items on toString() call", () => {
+      const error = new Errors.InternalError(new Error("throwing error"))
 
-    expect(error).toMatchObject({
-      message: `Could not integration with ${integrationName}`,
-      statusCode: HttpStatuses.integrationError
+      expect(error.toString()).toContain(`Internal Error: throwing error`)
+    })
+
+    it("should return correct lambdaResponse on toLambdaResponse() call", () => {
+      const error = new Errors.InternalError(new Error("throwing error"))
+
+      expect(error.toLambdaResponse()).toMatchObject({
+        statusCode: HttpStatuses.internalError,
+        body: JSON.stringify({ message: "throwing error" })
+      })
     })
   })
 
-  it("IntegrationError toString()", () => {
-    const integrationName = "microservice1"
-    const error = new Errors.IntegrationError(integrationName)
+  describe("IntegrationError", () => {
+    it("should return a IntegrationError with correct message and statusCode", () => {
+      const integrationName = "microservice1"
+      const error = new Errors.IntegrationError(integrationName)
 
-    expect(error.toString()).toContain(`Integration Error: Could not integration with ${integrationName}`)
-  })
+      expect(error).toMatchObject({
+        message: `Could not integration with ${integrationName}`,
+        statusCode: HttpStatuses.integrationError
+      })
+    })
 
-  it("should return correct lambdaResponse on toLambdaResponse() call", () => {
-    const integrationName = "microservice1"
-    const error = new Errors.IntegrationError(integrationName)
+    it("IntegrationError toString()", () => {
+      const integrationName = "microservice1"
+      const error = new Errors.IntegrationError(integrationName)
 
-    expect(error.toLambdaResponse()).toMatchObject({
-      statusCode: HttpStatuses.integrationError,
-      body: JSON.stringify({ message: `Could not integration with ${integrationName}` })
+      expect(error.toString()).toContain(`Integration Error: Could not integration with ${integrationName}`)
+    })
+
+    it("should return correct lambdaResponse on toLambdaResponse() call", () => {
+      const integrationName = "microservice1"
+      const error = new Errors.IntegrationError(integrationName)
+
+      expect(error.toLambdaResponse()).toMatchObject({
+        statusCode: HttpStatuses.integrationError,
+        body: JSON.stringify({ message: `Could not integration with ${integrationName}` })
+      })
+    })
+
+    it("should return a IntegrationError with correct message, statusCode, and customError message", () => {
+      const integrationName = "microservice1"
+      const customMessage = "microservice1 is offline"
+      const error = new Errors.IntegrationError(integrationName, customMessage)
+
+      expect(error).toMatchObject({
+        message: customMessage,
+        statusCode: HttpStatuses.integrationError,
+        customMessage
+      })
+    })
+
+    it("IntegrationError toString() with customError message", () => {
+      const integrationName = "microservice1"
+      const error = new Errors.IntegrationError(integrationName, "microservice1 is offline")
+
+      expect(error.toString()).toContain(`Integration Error: microservice1 is offline`)
+    })
+
+    it("should return correct lambdaResponse on toLambdaResponse() call with customError message", () => {
+      const integrationName = "microservice1"
+      const customMessage = "microservice1 is offline"
+      const error = new Errors.IntegrationError(integrationName, customMessage)
+
+      expect(error.toLambdaResponse()).toMatchObject({
+        statusCode: HttpStatuses.integrationError,
+        body: JSON.stringify({ message: customMessage })
+      })
     })
   })
 
-  it("should return a IntegrationError with correct message, statusCode, and customError message", () => {
-    const integrationName = "microservice1"
-    const customMessage = "microservice1 is offline"
-    const error = new Errors.IntegrationError(integrationName, customMessage)
+  describe("BadRequestError", () => {
+    it("should return a BadRequestError with correct message and statusCode", () => {
+      const errorMessage = "invalid appId"
+      const error = new Errors.BadRequestError(errorMessage)
 
-    expect(error).toMatchObject({
-      message: customMessage,
-      statusCode: HttpStatuses.integrationError,
-      customMessage
+      expect(error).toMatchObject({
+        message: errorMessage,
+        statusCode: HttpStatuses.badRequest
+      })
+    })
+
+    it("should return string containing correct items on toString() call", () => {
+      const errorMessage = "invalid appId"
+      const error = new Errors.BadRequestError(errorMessage)
+
+      expect(error.toString()).toContain(`Bad Request Error: ${errorMessage}`)
+    })
+
+    it("should return correct lambdaResponse on toLambdaResponse() call", () => {
+      const errorMessage = "invalid appId"
+      const error = new Errors.BadRequestError(errorMessage)
+
+      expect(error.toLambdaResponse()).toMatchObject({
+        statusCode: HttpStatuses.badRequest,
+        body: JSON.stringify({ message: errorMessage })
+      })
     })
   })
 
-  it("IntegrationError toString() with customError message", () => {
-    const integrationName = "microservice1"
-    const error = new Errors.IntegrationError(integrationName, "microservice1 is offline")
+  describe("NotFoundError", () => {
+    it("should return a NotFoundError with correct message and statusCode", () => {
+      const errorMessage = "thing not found"
+      const error = new Errors.NotFoundError(errorMessage)
 
-    expect(error.toString()).toContain(`Integration Error: microservice1 is offline`)
-  })
+      expect(error).toMatchObject({
+        message: errorMessage,
+        statusCode: HttpStatuses.notFound
+      })
+    })
 
-  it("should return correct lambdaResponse on toLambdaResponse() call with customError message", () => {
-    const integrationName = "microservice1"
-    const customMessage = "microservice1 is offline"
-    const error = new Errors.IntegrationError(integrationName, customMessage)
+    it("should return string containing correct items on toString() call", () => {
+      const errorMessage = "thing not found"
+      const error = new Errors.NotFoundError(errorMessage)
 
-    expect(error.toLambdaResponse()).toMatchObject({
-      statusCode: HttpStatuses.integrationError,
-      body: JSON.stringify({ message: customMessage })
+      expect(error.toString()).toContain(`Not Found Error: ${errorMessage}`)
+    })
+
+    it("should return correct lambdaResponse on toLambdaResponse() call", () => {
+      const errorMessage = "thing not found"
+      const error = new Errors.NotFoundError(errorMessage)
+
+      expect(error.toLambdaResponse()).toMatchObject({
+        statusCode: HttpStatuses.notFound,
+        body: JSON.stringify({ message: errorMessage })
+      })
     })
   })
-})
+  describe("UnauthorizedError", () => {
+    it("should return a UnauthorizedError with correct message and statusCode", () => {
+      const errorMessage = "not enough permissions"
+      const error = new Errors.UnauthorizedError(errorMessage)
 
-describe("BadRequestError", () => {
-  it("should return a BadRequestError with correct message and statusCode", () => {
-    const errorMessage = "invalid appId"
-    const error = new Errors.BadRequestError(errorMessage)
-
-    expect(error).toMatchObject({
-      message: errorMessage,
-      statusCode: HttpStatuses.badRequest
+      expect(error).toMatchObject({
+        message: errorMessage,
+        statusCode: HttpStatuses.unauthorized
+      })
     })
-  })
 
-  it("should return string containing correct items on toString() call", () => {
-    const errorMessage = "invalid appId"
-    const error = new Errors.BadRequestError(errorMessage)
+    it("should return string containing correct items on toString() call", () => {
+      const errorMessage = "not enough permissions"
+      const error = new Errors.UnauthorizedError(errorMessage)
 
-    expect(error.toString()).toContain(`Bad Request Error: ${errorMessage}`)
-  })
-
-  it("should return correct lambdaResponse on toLambdaResponse() call", () => {
-    const errorMessage = "invalid appId"
-    const error = new Errors.BadRequestError(errorMessage)
-
-    expect(error.toLambdaResponse()).toMatchObject({
-      statusCode: HttpStatuses.badRequest,
-      body: JSON.stringify({ message: errorMessage })
+      expect(error.toString()).toContain(`Unauthorized Error: ${errorMessage}`)
     })
-  })
-})
 
-describe("NotFoundError", () => {
-  it("should return a NotFoundError with correct message and statusCode", () => {
-    const errorMessage = "thing not found"
-    const error = new Errors.NotFoundError(errorMessage)
+    it("should return correct lambdaResponse on toLambdaResponse() call", () => {
+      const errorMessage = "not enough permissions"
+      const error = new Errors.UnauthorizedError(errorMessage)
 
-    expect(error).toMatchObject({
-      message: errorMessage,
-      statusCode: HttpStatuses.notFound
-    })
-  })
-
-  it("should return string containing correct items on toString() call", () => {
-    const errorMessage = "thing not found"
-    const error = new Errors.NotFoundError(errorMessage)
-
-    expect(error.toString()).toContain(`Not Found Error: ${errorMessage}`)
-  })
-
-  it("should return correct lambdaResponse on toLambdaResponse() call", () => {
-    const errorMessage = "thing not found"
-    const error = new Errors.NotFoundError(errorMessage)
-
-    expect(error.toLambdaResponse()).toMatchObject({
-      statusCode: HttpStatuses.notFound,
-      body: JSON.stringify({ message: errorMessage })
-    })
-  })
-})
-describe("UnauthorizedError", () => {
-  it("should return a UnauthorizedError with correct message and statusCode", () => {
-    const errorMessage = "not enough permissions"
-    const error = new Errors.UnauthorizedError(errorMessage)
-
-    expect(error).toMatchObject({
-      message: errorMessage,
-      statusCode: HttpStatuses.unauthorized
-    })
-  })
-
-  it("should return string containing correct items on toString() call", () => {
-    const errorMessage = "not enough permissions"
-    const error = new Errors.UnauthorizedError(errorMessage)
-
-    expect(error.toString()).toContain(`Unauthorized Error: ${errorMessage}`)
-  })
-
-  it("should return correct lambdaResponse on toLambdaResponse() call", () => {
-    const errorMessage = "not enough permissions"
-    const error = new Errors.UnauthorizedError(errorMessage)
-
-    expect(error.toLambdaResponse()).toMatchObject({
-      statusCode: HttpStatuses.unauthorized,
-      body: JSON.stringify({ message: errorMessage })
+      expect(error.toLambdaResponse()).toMatchObject({
+        statusCode: HttpStatuses.unauthorized,
+        body: JSON.stringify({ message: errorMessage })
+      })
     })
   })
 })

--- a/src/error/customErrors.test.ts
+++ b/src/error/customErrors.test.ts
@@ -1,6 +1,6 @@
 import { HttpStatuses } from ".."
+// skipcq: JS-C1003
 import * as Errors from "./customErrors"
-
 
 describe("CustomError", () => {
   describe("InternalError", () => {
@@ -16,7 +16,7 @@ describe("CustomError", () => {
     it("should return string containing correct items on toString() call", () => {
       const error = new Errors.InternalError(new Error("throwing error"))
 
-      expect(error.toString()).toContain(`Internal Error: throwing error`)
+      expect(error.toString()).toContain("Internal Error: throwing error")
     })
 
     it("should return correct lambdaResponse on toLambdaResponse() call", () => {
@@ -73,7 +73,7 @@ describe("CustomError", () => {
       const integrationName = "microservice1"
       const error = new Errors.IntegrationError(integrationName, "microservice1 is offline")
 
-      expect(error.toString()).toContain(`Integration Error: microservice1 is offline`)
+      expect(error.toString()).toContain("Integration Error: microservice1 is offline")
     })
 
     it("should return correct lambdaResponse on toLambdaResponse() call with customError message", () => {

--- a/src/error/customErrors.ts
+++ b/src/error/customErrors.ts
@@ -9,7 +9,7 @@ abstract class CustomError extends Error {
    * should be used for logging
    * @returns {string}
   */
-  public toString(): string {
+  public toString (): string {
     return `${this.kind}: ${this.message}${this.stack ? `\n${this.stack}` : ''}`
   }
 
@@ -19,7 +19,7 @@ abstract class CustomError extends Error {
    * after a 'instanceof' check -> if (err instanceof CustomError) ...
    * @returns {{statusCode: number, body: string}}
   */
-  public toLambdaResponse(): { statusCode: number, body: string } {
+  public toLambdaResponse (): { statusCode: number, body: string } {
     return {
       statusCode: this.statusCode,
       body: JSON.stringify({ message: this.message })
@@ -37,7 +37,7 @@ class IntegrationError extends CustomError {
   kind = 'Integration Error'
   protected customMessage: string
 
-  constructor(protected integration: string, protected errorMessage?: string) {
+  constructor (protected integration: string, protected errorMessage?: string) {
     const message = errorMessage ?? `Could not integration with ${integration}`
     super(message)
     this.customMessage = message
@@ -48,17 +48,15 @@ class InternalError extends CustomError {
   statusCode = HttpStatuses.internalError
   kind = 'Internal Error'
 
-  constructor(error: unknown) {
+  constructor (error: unknown) {
     super('An internal error occurred')
 
     if (typeof error === 'string') {
       this.message = error
-    }
-    else if (typeof error === 'object' && 'message' in error! && 'statusCode' in error!) {
+    } else if (typeof error === 'object' && 'message' in error! && 'statusCode' in error) {
       this.message = error.message as string
       this.statusCode = error.statusCode as HttpStatuses
-    }
-    else if (typeof error === 'object' && 'message' in error!) {
+    } else if (typeof error === 'object' && 'message' in error!) {
       this.message = error.message as string
     }
   }
@@ -80,5 +78,5 @@ export {
   IntegrationError,
   InternalError,
   NotFoundError,
-  UnauthorizedError,
+  UnauthorizedError
 }

--- a/src/error/customErrors.ts
+++ b/src/error/customErrors.ts
@@ -1,0 +1,95 @@
+import { HttpStatuses } from ".."
+
+abstract class CustomError extends Error {
+  abstract statusCode: number
+  abstract kind: string
+
+  constructor(message: string) {
+    super(message)
+  }
+
+  /**
+   * Returns a string representation of the error
+   * should be used for logging
+   * @returns {string}
+  */
+  public toString(): string {
+    return `${this.kind}: ${this.message}${this.stack ? `\n${this.stack}` : ""}`
+  }
+
+  /**
+   * Returns a lambda response object
+   * should be used for returning errors in lambda functions
+   * after a "instanceof" check -> if (err instanceof CustomError) ...
+   * @returns {{statusCode: number, body: string}}
+  */
+  public toLambdaResponse(): { statusCode: number, body: string } {
+    return {
+      statusCode: this.statusCode,
+      body: JSON.stringify({ message: this.message })
+    }
+  }
+}
+
+class BadRequestError extends CustomError {
+  statusCode = HttpStatuses.badRequest
+  kind = "Bad Request Error"
+}
+
+class IntegrationError extends CustomError {
+  statusCode = HttpStatuses.integrationError
+  kind = "Integration Error"
+  protected customMessage: string
+
+  constructor(protected integration: string, protected errorMessage?: string) {
+    super(errorMessage ?? `Could not integration with ${integration}`)
+    this.customMessage = errorMessage ?? `Could not integration with ${integration}`
+  }
+}
+
+class InternalError extends CustomError {
+  statusCode = HttpStatuses.internalError
+  kind = "Internal Error"
+
+  constructor(error: unknown) {
+    super("An internal error occurred")
+
+    if (typeof error === "string") {
+      this.message = error
+    }
+    else if (typeof error === "object" && "message" in error! && "statusCode" in error!) {
+      this.message = error.message as string
+      this.statusCode = error.statusCode as HttpStatuses
+    }
+    else if (typeof error === "object" && "message" in error!) {
+      this.message = error.message as string
+    }
+  }
+}
+
+class NotFoundError extends CustomError {
+  statusCode = HttpStatuses.notFound
+  kind = "Not Found Error"
+
+  constructor(message: string) {
+    super(message)
+  }
+}
+
+class UnauthorizedError extends CustomError {
+  statusCode = HttpStatuses.unauthorized
+  kind = "Unauthorized Error"
+
+  constructor(message: string) {
+    super(message)
+  }
+}
+
+export {
+  BadRequestError,
+  CustomError,
+  IntegrationError,
+  InternalError,
+  NotFoundError,
+  UnauthorizedError,
+}

--- a/src/error/customErrors.ts
+++ b/src/error/customErrors.ts
@@ -4,10 +4,6 @@ abstract class CustomError extends Error {
   abstract statusCode: number
   abstract kind: string
 
-  constructor(message: string) {
-    super(message)
-  }
-
   /**
    * Returns a string representation of the error
    * should be used for logging
@@ -71,19 +67,11 @@ class InternalError extends CustomError {
 class NotFoundError extends CustomError {
   statusCode = HttpStatuses.notFound
   kind = "Not Found Error"
-
-  constructor(message: string) {
-    super(message)
-  }
 }
 
 class UnauthorizedError extends CustomError {
   statusCode = HttpStatuses.unauthorized
   kind = "Unauthorized Error"
-
-  constructor(message: string) {
-    super(message)
-  }
 }
 
 export {

--- a/src/error/customErrors.ts
+++ b/src/error/customErrors.ts
@@ -42,8 +42,9 @@ class IntegrationError extends CustomError {
   protected customMessage: string
 
   constructor(protected integration: string, protected errorMessage?: string) {
-    super(errorMessage ?? `Could not integration with ${integration}`)
-    this.customMessage = errorMessage ?? `Could not integration with ${integration}`
+    const message = errorMessage ?? `Could not integration with ${integration}`
+    super(message)
+    this.customMessage = message
   }
 }
 

--- a/src/error/customErrors.ts
+++ b/src/error/customErrors.ts
@@ -1,4 +1,4 @@
-import { HttpStatuses } from ".."
+import { HttpStatuses } from '..'
 
 abstract class CustomError extends Error {
   abstract statusCode: number
@@ -10,13 +10,13 @@ abstract class CustomError extends Error {
    * @returns {string}
   */
   public toString(): string {
-    return `${this.kind}: ${this.message}${this.stack ? `\n${this.stack}` : ""}`
+    return `${this.kind}: ${this.message}${this.stack ? `\n${this.stack}` : ''}`
   }
 
   /**
    * Returns a lambda response object
    * should be used for returning errors in lambda functions
-   * after a "instanceof" check -> if (err instanceof CustomError) ...
+   * after a 'instanceof' check -> if (err instanceof CustomError) ...
    * @returns {{statusCode: number, body: string}}
   */
   public toLambdaResponse(): { statusCode: number, body: string } {
@@ -29,12 +29,12 @@ abstract class CustomError extends Error {
 
 class BadRequestError extends CustomError {
   statusCode = HttpStatuses.badRequest
-  kind = "Bad Request Error"
+  kind = 'Bad Request Error'
 }
 
 class IntegrationError extends CustomError {
   statusCode = HttpStatuses.integrationError
-  kind = "Integration Error"
+  kind = 'Integration Error'
   protected customMessage: string
 
   constructor(protected integration: string, protected errorMessage?: string) {
@@ -46,19 +46,19 @@ class IntegrationError extends CustomError {
 
 class InternalError extends CustomError {
   statusCode = HttpStatuses.internalError
-  kind = "Internal Error"
+  kind = 'Internal Error'
 
   constructor(error: unknown) {
-    super("An internal error occurred")
+    super('An internal error occurred')
 
-    if (typeof error === "string") {
+    if (typeof error === 'string') {
       this.message = error
     }
-    else if (typeof error === "object" && "message" in error! && "statusCode" in error!) {
+    else if (typeof error === 'object' && 'message' in error! && 'statusCode' in error!) {
       this.message = error.message as string
       this.statusCode = error.statusCode as HttpStatuses
     }
-    else if (typeof error === "object" && "message" in error!) {
+    else if (typeof error === 'object' && 'message' in error!) {
       this.message = error.message as string
     }
   }
@@ -66,12 +66,12 @@ class InternalError extends CustomError {
 
 class NotFoundError extends CustomError {
   statusCode = HttpStatuses.notFound
-  kind = "Not Found Error"
+  kind = 'Not Found Error'
 }
 
 class UnauthorizedError extends CustomError {
   statusCode = HttpStatuses.unauthorized
-  kind = "Unauthorized Error"
+  kind = 'Unauthorized Error'
 }
 
 export {

--- a/src/error/index.ts
+++ b/src/error/index.ts
@@ -1,5 +1,7 @@
 import { isString } from '../string'
 
+export * from './customErrors'
+
 export const error = (statusCode: number, err: any): object => ({
   statusCode,
   ...(!isString(err) ? { error: err } : { message: err })

--- a/src/s3/formatters.ts
+++ b/src/s3/formatters.ts
@@ -1,4 +1,4 @@
-import { Readable } from 'stream';
+import { Readable } from 'stream'
 
 export const streamToString = async (stream: Readable) => new Promise((resolve, reject) => {
   const chunks: any[] = []


### PR DESCRIPTION
### Description
Create class based custom errors to easily check for errors on catch blocks

```js
try {
} catch (err) }
  if (err instaceof CustomError) {
    console.error(err.toString())
    return err.toLambdaResponse()
  }

  // handle non CustomError
}
```