### PR TITLE
[FEAT] Cria a opção de passar um customHost para o invokeLambda

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "adapcon-utils-js",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "adapcon-utils-js",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.496.0",
         "@aws-sdk/client-lambda": "^3.496.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adapcon-utils-js",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Utils library for Javascript",
   "keywords": [],
   "author": {

--- a/src/lambda/interfaces.ts
+++ b/src/lambda/interfaces.ts
@@ -29,7 +29,7 @@ export interface lambdaParameters {
   queryStringParameters?: {[key: string]: any}
   multiValueQueryStringParameters?: {[key: string]: any}
   isOffline?: boolean
-  isDocker?: boolean
+  customHost?: string
   serviceSecretArn?: string
   path?: string
   requestContext?: object

--- a/src/lambda/interfaces.ts
+++ b/src/lambda/interfaces.ts
@@ -29,6 +29,7 @@ export interface lambdaParameters {
   queryStringParameters?: {[key: string]: any}
   multiValueQueryStringParameters?: {[key: string]: any}
   isOffline?: boolean
+  isDocker?: boolean
   serviceSecretArn?: string
   path?: string
   requestContext?: object

--- a/src/lambda/lambdaService.ts
+++ b/src/lambda/lambdaService.ts
@@ -32,7 +32,7 @@ const executeInvoke = async <T>({
   queryStringParameters = {},
   multiValueQueryStringParameters = {},
   isOffline = false,
-  isDocker = false,
+  customHost,
   httpMethod = '',
   path,
   requestContext = {},
@@ -41,7 +41,7 @@ const executeInvoke = async <T>({
   accessKeyId?: string
   secretAccessKey?: string
 } & lambdaParameters) => {
-  const lambdaSettings: LambdaClientConfig = getLambdaConfig(region, accessKeyId, secretAccessKey, isOffline, port, isDocker)
+  const lambdaSettings: LambdaClientConfig = getLambdaConfig(region, accessKeyId, secretAccessKey, isOffline, port, customHost)
   const lambda = new Lambda(lambdaSettings)
 
   const response = await lambda.invoke({
@@ -77,7 +77,7 @@ const getLambdaConfig = (
   secretAccessKey: string | undefined,
   isOffline: boolean,
   port: string,
-  isDocker: boolean
+  customHost: string
 ) => {
   const lambdaSettings: LambdaClientConfig = { region }
   if (accessKeyId && secretAccessKey) {
@@ -88,7 +88,7 @@ const getLambdaConfig = (
   }
   if (isOffline) {
     lambdaSettings.region = 'localhost'
-    lambdaSettings.endpoint = isDocker ? `http://host.docker.internal:${port}` : `http://localhost:${port}`
+    lambdaSettings.endpoint = customHost ? `http://${customHost}:${port}` : `http://localhost:${port}`
   }
 
   return lambdaSettings

--- a/src/lambda/lambdaService.ts
+++ b/src/lambda/lambdaService.ts
@@ -32,6 +32,7 @@ const executeInvoke = async <T>({
   queryStringParameters = {},
   multiValueQueryStringParameters = {},
   isOffline = false,
+  isDocker = false,
   httpMethod = '',
   path,
   requestContext = {},
@@ -40,7 +41,7 @@ const executeInvoke = async <T>({
   accessKeyId?: string
   secretAccessKey?: string
 } & lambdaParameters) => {
-  const lambdaSettings: LambdaClientConfig = getLambdaConfig(region, accessKeyId, secretAccessKey, isOffline, port)
+  const lambdaSettings: LambdaClientConfig = getLambdaConfig(region, accessKeyId, secretAccessKey, isOffline, port, isDocker)
   const lambda = new Lambda(lambdaSettings)
 
   const response = await lambda.invoke({
@@ -70,7 +71,14 @@ const executeInvoke = async <T>({
   return formattedResponse<T>(response)
 }
 
-const getLambdaConfig = (region: string, accessKeyId: string | undefined, secretAccessKey: string | undefined, isOffline: boolean, port: string) => {
+const getLambdaConfig = (
+  region: string,
+  accessKeyId: string | undefined,
+  secretAccessKey: string | undefined,
+  isOffline: boolean,
+  port: string,
+  isDocker: boolean
+) => {
   const lambdaSettings: LambdaClientConfig = { region }
   if (accessKeyId && secretAccessKey) {
     lambdaSettings.credentials = {
@@ -80,7 +88,8 @@ const getLambdaConfig = (region: string, accessKeyId: string | undefined, secret
   }
   if (isOffline) {
     lambdaSettings.region = 'localhost'
-    lambdaSettings.endpoint = `http://localhost:${port}`
+    lambdaSettings.endpoint = isDocker ? `http://host.docker.internal:${port}` : `http://localhost:${port}`
   }
+
   return lambdaSettings
 }

--- a/src/lambda/lambdaService.ts
+++ b/src/lambda/lambdaService.ts
@@ -77,7 +77,7 @@ const getLambdaConfig = (
   secretAccessKey: string | undefined,
   isOffline: boolean,
   port: string,
-  customHost: string
+  customHost?: string
 ) => {
   const lambdaSettings: LambdaClientConfig = { region }
   if (accessKeyId && secretAccessKey) {


### PR DESCRIPTION
Adiciona a opção de se passar um customHost para o Invoke.
Isso permite uma comunicação entre diferentes devcontainers que estejam na mesma rede.

![image](https://github.com/user-attachments/assets/a13244a3-3e40-4bde-b1d7-10aa7e2dafc7)


