### PR TITLE
[AD1-T22] - Ajusta obrigatoriedade na prop do Docfy - pathParameters 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "adapcon-utils-js",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "adapcon-utils-js",
-      "version": "1.7.1",
+      "version": "1.7.2",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.496.0",
         "@aws-sdk/client-lambda": "^3.496.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adapcon-utils-js",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "Utils library for Javascript",
   "keywords": [],
   "author": {

--- a/src/lambda/interfaces.ts
+++ b/src/lambda/interfaces.ts
@@ -61,7 +61,7 @@ export type LambdaFunctionTypes = 'screen' | 'integration' | 'public' | 'session
 export type Docfy = {
   type: LambdaFunctionTypes
   description: string
-  pathParameters?: Record<string, Omit<DocfySettings, 'required'>>
+  pathParameters?: Record<string, DocfySettings>
   queryStringParameters?: Record<string, DocfySettings>
   headers?: Record<string, DocfySettings>
   body?: Record<string, DocfySettings>


### PR DESCRIPTION
Após o desenvolvimento das rotas do módulo de Automação de Notificação, precisou ser removido a tipagem que remove a obrigatoriedade no `pathParameters`, pois a mesma rota poderá chamar com ou sem um `pathParameters`.

![image](https://github.com/user-attachments/assets/5e85459b-8e96-41cc-8e16-798483d72d34)
 