### PR TITLE
fix: remove error throw when missing origin header

### DIFF
--- a/__tests__/lambda/lambdaResponseCors.test.ts
+++ b/__tests__/lambda/lambdaResponseCors.test.ts
@@ -96,18 +96,23 @@ describe('lambdaResponseCorsHeaders', () => {
     })
   })
 
-  it('throws an error when the origin header is missing from the request', () => {
+  it('returns empty origin when the origin header is missing from the request', () => {
     const modifiedEvent = {
       ...MockEvent.event,
       headers: {},
     } as APIGatewayProxyEvent
 
-    expect(() => {
-      lambdaResponseCorsHeaders({
-        event: modifiedEvent,
-        allowedMethods: ['GET'],
-      })
-    }).toThrow('Origin header is missing in the event')
+    const response = lambdaResponseCorsHeaders({
+      event: modifiedEvent,
+      allowedMethods: ['GET'],
+    })
+
+    expect(response).toEqual({
+      'Access-Control-Allow-Origin': '',
+      'Access-Control-Allow-Methods': 'GET,OPTIONS',
+      'Access-Control-Allow-Headers': '*',
+      'Access-Control-Max-Age': '0',
+    })
   })
 
   it('throws an error when the origin header is invalid', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "adapcon-utils-js",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "adapcon-utils-js",
-      "version": "1.10.0",
+      "version": "1.10.1",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.582.0",
         "@aws-sdk/client-lambda": "^3.496.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adapcon-utils-js",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Utils library for Javascript",
   "keywords": [],
   "author": {


### PR DESCRIPTION
###Description

* remove error thrown when origin header is missing, because in cases where we call an endpoint via Insomnia, Postman or another origin other than the website itself, it does not send an origin header