### PR TITLE
[FIX] Aumentando batch get limit para 100

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "adapcon-utils-js",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adapcon-utils-js",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "Utils library for Javascript",
   "keywords": [],
   "author": {

--- a/src/dao/dynamo/dao.ts
+++ b/src/dao/dynamo/dao.ts
@@ -82,10 +82,10 @@ async function scan<T> (params: ScanCommandInput): Promise<ScanOutput<T>> {
 const getAll = async ({ params, list, fields = [] }: { params: DynamodbParams, list: object[], fields?: string[] }) => {
   let idx = 0
 
-  // ? Pack 25 requests at a time (batchGet limit)
+  // ? Pack 100 requests at a time (batchGet limit)
 
   const packs: any = list.reduce((acc, param) => {
-    if (acc[idx] && acc[idx].length >= 25) idx++
+    if (acc[idx] && acc[idx].length >= 100) idx++
 
     if (!acc[idx]) acc[idx] = []
 


### PR DESCRIPTION
No código constava que o batch get limit era 25, porém o limit de get é 100, isso foi corrigido, visando aumentar o desempenho dos batch get do AMC e demais aplicações.